### PR TITLE
Fix pull-scripts to pull to a temporary directory to avoid workspace conflict

### DIFF
--- a/scripts/charts-build-scripts/pull-scripts
+++ b/scripts/charts-build-scripts/pull-scripts
@@ -34,14 +34,28 @@ if ! [[ -f bin/charts-build-scripts ]] || [[ "$(cat bin/charts-build-scripts)" =
     
     # Fall back to old process
     echo "Building binary locally..."
+    
+    # Building in a temporary directory
+    CURR_DIR=$(pwd)
+    TEMP_DIR=$(mktemp -d)
+    cd $TEMP_DIR
+    echo ${TEMP_DIR}
+    cleanup() {
+        set +e
+        cd ${CURR_DIR}
+        [[ -n "${TEMP_DIR}" ]] && [[ -d "${TEMP_DIR}" ]] && rm -rf ${TEMP_DIR}
+    }
+    trap 'cleanup' EXIT
+    
     [[ -d charts-build-scripts ]] && rm -rf charts-build-scripts
     git clone --depth 1 --branch $CHARTS_BUILD_SCRIPT_VERSION $CHARTS_BUILD_SCRIPTS_REPO 2>/dev/null
 
     cd charts-build-scripts
     VERSION_OVERRIDE=${CHARTS_BUILD_SCRIPT_VERSION} ./scripts/build
-    mv bin/charts-build-scripts ../bin/charts-build-scripts
-    cd ..
-    rm -rf charts-build-scripts
+    mv bin/charts-build-scripts ${CURR_DIR}/bin/charts-build-scripts
+    
+    # Return to original directory
+    cd ${CURR_DIR}
 else
     echo "${BINARY_NAME} => ./bin/charts-build-scripts"
 fi


### PR DESCRIPTION
Since we use go workspaces, we need to make sure a temporary directory is used to avoid an error like the following in the case of a local binary build (i.e. arm64):

```bash
Pulling in charts-build-scripts version https://github.com/rancher/charts-build-scripts.git@v0.4.0
Building binary locally...
main module (github.com/aiyengar2/Rancher-Plugin-gMSA) does not contain package github.com/aiyengar2/Rancher-Plugin-gMSA/charts-build-scripts
make: *** [charts] Error 1
```